### PR TITLE
Add error checking GUI for mixture files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .Rhistory
 .RData
 .Ruserdata
+
+.DS_Store

--- a/R/checkMixtureFile.R
+++ b/R/checkMixtureFile.R
@@ -1,0 +1,74 @@
+# File checkMixtureFile.R
+#
+# Elias Hernandis <eliashernandis@gmail.com>
+#
+# Given a mixture filepath this function attempts to load it.
+#
+# It returns a list containing a dataframe, a list of warnings and a list of
+# errors. If there are fatal errors, the dataframe will be FALSE. If there are
+# fixable errors (see the README for details), the dataframe will contain the
+# data from the mixture file but with those errors already fixed. The original
+# data file will not be updated. In the event of ambiguous or possibly wrong
+# marker names or sample names, the function will report them as warnings but
+# not fix them automatically.
+
+# source('util.R')
+
+checkMixtureFile <- function(filename) {
+    r <- commonChecks(filename, "reference file");
+    df <- r$df;
+    warning <- r$warning;
+    error <- r$error;
+
+    # check header column count
+    if (!is.null(df) && ncol(df) != 5) {
+        error <- "Incorrect number of columns"
+    }
+
+    referenceHeader <- c("SampleName", "Marker", "Allele1", "Allele2", "Allele3")
+
+    if (length(error) == 0 && any(referenceHeader != names(df))) {
+        warning <- append(warning, "Column titles must be written without spaces and with the first letter uppercased (fixed).");
+
+        fixedHeader <- sapply(names(df), titleize);
+        fixedHeader[1] <- "SampleName"; # special case for the first column header, which is "SampleName" instead of "Sample Name"
+
+        if (all(fixedHeader != names(df))) {
+            error <- append(error, paste("There are problems with the header row of the mixture table. Please make sure it is the following: ", referenceHeader));
+        } else {
+            # if the errors are minor, fix the header for the user
+            names(df) <- referenceHeader;
+        }
+    }
+
+
+    # Detect possible mistakes with similar SampleNames
+    sampleNames <- unique(df$SampleName);
+    if (length(sampleNames) > 1) {
+        comb <- combn(sampleNames, 2)
+        for (i in 1:ncol(comb)) {
+            if (levenshteinDistance(comb[1,i], comb[2,i]) == 1) {
+                warning <- append(warning, paste("Two very similar sample names were found in the mixture file. Did you mean", comb[1,i], "or", comb[2,i],"?"));
+            }
+        }
+    }
+
+    # Check all allele reference data is numeric
+    if (length(error) == 0 && !all(sapply(df[,3], is.numeric))) {
+        error <- "There are values that are not numeric in the Allele1 column of the mixture file";
+    }
+
+    if (!all(sapply(df[,4], is.numeric))) {
+        error <- append(error, "There are values that are not numeric in hte Allele2 column of the mixture file");
+    }
+
+    if (!all(sapply(df[,5], is.numeric))) {
+        error <- append(error, "There are values that are not numeric in hte Allele3 column of the mixture file");
+    }
+
+    if (length(error) > 0) {
+        return(list(df=NULL, warning=NULL, error=error));
+    }
+
+    return(list(df=df, warning=warning, error=NULL));
+}

--- a/R/relMixGUI.R
+++ b/R/relMixGUI.R
@@ -22,12 +22,36 @@ relMixGUI <- function(){
   tableWriter <- function(filename,obj){
     write.table(obj,file=filename,sep="\t",row.names=FALSE,quote=FALSE)
   }
-  
+
+  # Receives a the output of an error checking function and displays
+  # the appropriate error messages. Returns the data frame on
+  # successfull load or NULL on error.
+  process_errors <- function(result) {
+      message = "";
+      if (length(result$error) > 0) {
+          message <- paste(message, "Error(s):\n", result$error, sep="\n");
+          message <- paste(message, "These errors are fatal. You will need to fix the file yourself.", sep="\n");
+      }
+
+      if (length(result$warning) > 0) {
+          message <- paste(message, "Warning(s):\n", result$warning, sep="\n");
+          message <- paste(message, "These warnings are not fatal. You may continue using the program but please be aware that results may be incorrect.", sep="\n");
+      }
+
+      f_errorWindow(message);
+
+      return(result$df);
+  }
+
   f_importprof <- function(h,...) {
     type=h$action #get type of profile
     proffile = gfile(text=paste("Open ",type," file",sep=""),type="open",
                      filter=list("text"=list(patterns=list("*.txt","*.csv","*.tab")),"all"=list(patterns=list("*"))))
-    Data <- tableReader(proffile) #load profile
+
+
+    # check errors
+    Data <- process_errors(checkMixtureFile(proffile));
+
     assign(h$action,Data,envir=mmTK) #save object
   }
   
@@ -106,7 +130,7 @@ relMixGUI <- function(){
   #Pop-up error window
   f_errorWindow <- function(message){
     errorWindow <- gwindow("Error")
-    glabel(message,container=errorWindow)
+    glabel(message,container=errorWindow, expand=TRUE)
     gbutton("ok", container=errorWindow,handler=function(h,...){
       dispose(h$obj)
     })

--- a/R/util.R
+++ b/R/util.R
@@ -1,0 +1,55 @@
+# File util.R
+#
+# Elias Hernandis <eliashernandis@gmail.com>
+
+# Given a string it returns it all lowercase with only the first letter of each
+# word uppercase. It leaves non alphabetical characters untouched.
+titleize <- function(x) {
+    s <- strsplit(x, " ")[[1]];
+    paste(toupper(substring(s, 1,1)), tolower(substring(s, 2)), sep="", collapse=" ")
+}
+
+# Given a TSV file this function performs some sanity checks on it, reporting
+# fatal errors if they arise. See the README for details.
+commonChecks <- function(filename, fileType) {
+    error <- c();
+    warning <- c();
+    df <- tryCatch(
+                   read.table(filename, header=TRUE, sep="\t", stringsAsFactors=FALSE),
+                   error = function(e) { NULL });
+
+    if (is.null(df)) {
+        error <- append(error, paste("The", fileType, "you provided is not a well-formed tab-separated value (TSV) file. This can be avoided by generating the mixture file with a spreadsheet program instead of composing the file by hand."));
+    }
+
+    return(list(warning = warning, error = error, df = df));
+}
+
+# Given a pair of strings this function computes the Levenshtein distance
+# between them, that is, an indication of the number of mistakes it takes to
+# mistype one given the other is the correct one.
+levenshteinDistance <- function(s1, s2) {
+    m <- nchar(s1);
+    n <- nchar(s2);
+    t1 <- strsplit(s1, '')[[1]]
+    t2 <- strsplit(s2, '')[[1]]
+    d <- matrix(0, m+1, n+1);
+    d[,1] <- matrix(0:m);
+    d[1,] <- matrix(0:n);
+
+    for (i in 1:m) {
+        for (j in 1:n) {
+            substCost <- 1;
+            if (t1[i] == t2[j]) {
+                substCost <- 0;
+            }
+
+            d[i+1,j+1] <- min(
+                              d[i, j+1] + 1,
+                              d[i+1, j] + 1,
+                              d[i, j] + substCost
+                              );
+        }
+    }
+    return(d[m+1,n+1]);
+}

--- a/man/relMixGUI.Rd
+++ b/man/relMixGUI.Rd
@@ -12,6 +12,8 @@ relMixGUI()
 }
 \details{
 Note that if mutation model 'Stepwise' is used, it is required that the names of all non-silent alleles are positive integers. See \code{\link[Familias]{FamiliasLocus}} for details about the mutation models.
+
+Includes error checking for mixture files.
 }
 \author{
 Guro Dorum


### PR DESCRIPTION
* Modify `relMixGUI.R` to use the error checking code from the new files
(`util.R` and `checkMixtureFile.R`).
* Define the function `process_errors` in the `relMixGUI.R` file to
handle the output of the error checking functions and show error dialogs
as needed.

Shortcomings:
* Long error messages cause the error dialog to span the entire width of
the string.
* Non-TSV files (other types of files such as images) do not trigger an
error, probably due to the use of `read.table`.